### PR TITLE
Change exec to sugar-python3

### DIFF
--- a/activity/activity.info
+++ b/activity/activity.info
@@ -6,6 +6,6 @@ license = GPLv2+
 url = http://www.gcompris.org/
 tags = Education;Game
 icon = activity-icon
-exec = sugar-activity activity.GComprisLauncher
+exec = sugar-activity3 activity.GComprisLauncher
 activity_version = 20
 bundle_id = org.gcompris


### PR DESCRIPTION
This fixes https://github.com/sugarlabs/gcompris-wrapper-activity/issues/2. No additional porting besides adjustment of the exec type appears to be required. Tested in a `sugar-activity3` testing environment and within a local sugar install.